### PR TITLE
Added content root for service

### DIFF
--- a/ImageCompressor.Service/Program.cs
+++ b/ImageCompressor.Service/Program.cs
@@ -4,12 +4,12 @@ using Microsoft.Extensions.Options;
 using Serilog;
 
 var configuration = new ConfigurationBuilder()
-    .SetBasePath(Directory.GetCurrentDirectory())
     .AddJsonFile("appsettings.json")
     .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", true)
     .Build();
 
 IHost host = Host.CreateDefaultBuilder(args)
+    .UseContentRoot(AppContext.BaseDirectory)
     .ConfigureServices(services =>
     {
         services.AddOptions<SettingsRoot>()


### PR DESCRIPTION
- avoid appsettings.json to be found in the current directory

Fixed breaking change of .net7: https://learn.microsoft.com/en-us/dotnet/core/compatibility/extensions/7.0/contentrootpath-hosted-app